### PR TITLE
Fix three issues: init `__what_to_create`, honor `resample_dt`, and correct `get_t_isco` indexing

### DIFF
--- a/gwBOB/BOB_utils.py
+++ b/gwBOB/BOB_utils.py
@@ -619,7 +619,7 @@ class BOB:
             float: Time of ISCO of the waveform
         '''
         freq_data = gen_utils.get_frequency(self.data).cropped(init=self.tp-100,end=self.tp+50)
-        t_isco = self.data.t[gen_utils.find_nearest_index(freq_data.y,self.Omega_ISCO*np.abs(self.m))]
+        t_isco = freq_data.t[gen_utils.find_nearest_index(freq_data.y,self.Omega_ISCO*np.abs(self.m))]
         return t_isco - self.tp
 
     def construct_BOB_finite_t0(self,N):

--- a/gwBOB/BOB_utils.py
+++ b/gwBOB/BOB_utils.py
@@ -63,6 +63,7 @@ class BOB:
         self.tp = 0
         
         self.what_is_BOB_building="Nothing"
+        self.__what_to_create = "Nothing"
         self.l = 2
         self.m = 2
         self.Phi_0 = 0
@@ -1123,6 +1124,8 @@ class BOB:
             raise ValueError("m=0 case not implemented yet")
         import qnmfits #adding here so this code can be used without WSL for non-cce purposes
         print("loading CCE id",cce_id)
+
+        self.resample_dt = resample_dt
 
         if(provide_own_abd is None):
             abd = qnmfits.cce.load(cce_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gwBOB"
-version = "1.0.1"
+version = "1.0.2"
 description = "A Backwards-One-Body Gravitational Waveform Package"
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [


### PR DESCRIPTION
### Motivation
- `set_initial_time` referenced `self.__what_to_create` before it was initialized, which can raise an `AttributeError` if initial time is set prior to selecting what to create. 
- The CCE initialization routine accepted a `resample_dt` argument but did not apply it, causing callers to be ignored. 
- `get_t_isco` computed a nearest-frequency index from a cropped frequency array but indexed the uncropped time array, producing incorrect ISCO time lookups. 

### Description
- Initialize `self.__what_to_create = "Nothing"` in the `BOB.__init__` constructor to ensure the attribute exists before `set_initial_time` uses it. 
- Set `self.resample_dt = resample_dt` at the start of the CCE initialization function so the passed `resample_dt` is honored for resampling. 
- Replace indexing of `self.data.t[...]` with `freq_data.t[...]` in `get_t_isco` so the time lookup matches the cropped frequency array used to compute the index. 

### Testing
- Executed automated edit-and-verify scripts that applied the three minimal changes and read back `gwBOB/BOB_utils.py` to confirm the intended lines were modified, and those checks passed. 
- No project unit test suite (e.g. `pytest`) was executed for these changes. 
- Performed static inspection of the modified lines to confirm each fix is a single-line, localized change and no other behavior was altered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698606095500832786932b49f3918a3e)