### PR TITLE
Lazy-load qnm data and add error handling

### DIFF
--- a/gwBOB/BOB_utils.py
+++ b/gwBOB/BOB_utils.py
@@ -54,7 +54,7 @@ class BOB:
         Initializes the BOB object with default values. By default a least squares optimization is performed. 
 
         '''
-        qnm.download_data()
+        self._qnm_data_ready = False
         #some default values
         self.minf_t0 = True
         self.__start_before_tpeak = -75
@@ -99,6 +99,21 @@ class BOB:
         #flag to see if a attempted fit failed
         self.fit_failed = False
 
+    def _ensure_qnm_data_ready(self):
+        '''
+        Lazily downloads qnm data the first time BOB needs it.
+        '''
+        if self._qnm_data_ready:
+            return
+        try:
+            qnm.download_data()
+            self._qnm_data_ready = True
+        except Exception as exc:
+            raise RuntimeError(
+                "Unable to initialize qnm data. "
+                "Please check your network/filesystem access and retry."
+            ) from exc
+
     @property
     def what_should_BOB_create(self):
         '''
@@ -117,6 +132,7 @@ class BOB:
             ValueError: If the value is not one of the allowed values
         '''
         val = value.lower()
+        self._ensure_qnm_data_ready()
         if(val=="psi4" or val=="strain_using_psi4"):
             self.__what_to_create = val
             self.data = self.psi4_data


### PR DESCRIPTION
### Motivation
- Avoid performing an eager `qnm.download_data()` call in `__init__` which can fail or be unnecessary at object construction time.
- Improve robustness by providing clearer error handling and only downloading QNM data when it is actually needed.

### Description
- Remove the eager `qnm.download_data()` call from `__init__` and introduce the flag `self._qnm_data_ready = False` to track initialization state.
- Add a new helper method `_ensure_qnm_data_ready()` that lazily calls `qnm.download_data()` and raises a `RuntimeError` with a clear message if initialization fails.
- Invoke `_ensure_qnm_data_ready()` at the start of the `what_should_BOB_create` setter so QNM data is available before performing operations that depend on it.
- Add a minor EOF newline fix.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c410d6e1208327854447c6dda208b5)